### PR TITLE
Externalise the config of the registry id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY static /app/static
 COPY main.py /app/
 COPY run /app/
 
+RUN chown -Rv gunicorn: /app
+
 WORKDIR /app
 USER gunicorn
 EXPOSE 8080/tcp

--- a/run
+++ b/run
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ -n "$REGISTRY_ID" ]]; then
+    echo "Templating config.js with REGISTRY_ID=$REGISTRY_ID"
+    sed -ie "s/REPLACE_ME/$REGISTRY_ID/g" static/js/config.js
+fi
+
 exec gunicorn \
     --workers 10 \
     --timeout=120  \

--- a/static/index.html
+++ b/static/index.html
@@ -8,6 +8,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <!-- client side config -->
+    <script src="static/js/config.js"></script>
+
     <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="static/js/index.js"></script>
 

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -1,0 +1,1 @@
+var registryID = 'REPLACE_ME';

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,4 +1,3 @@
-var registryID = '226617721124';
 
 $(document).ready(function(){
     HandlebarsIntl.registerWith(Handlebars);


### PR DESCRIPTION
I've broken out the registry id into the `config.js` file. The docker also now contains support for a `REGISTRY_ID` variable, templating out the `config.js` at run time.